### PR TITLE
[Android] 修复小组件刷新 & 点击小组件进入应用

### DIFF
--- a/modules/widget/android/src/main/AndroidManifest.xml
+++ b/modules/widget/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
   <application>
     <receiver
       android:name="dev.tokenteam.iwut.widget.ScheduleWidget"

--- a/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleWidget.kt
+++ b/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleWidget.kt
@@ -40,7 +40,8 @@ class ScheduleWidget : AppWidgetProvider() {
         const val ACTION_AUTO_REFRESH = "dev.tokenteam.iwut.widget.AUTO_REFRESH"
 
         // Do not use `0` for request code
-        const val REQUEST_CODE = 1234
+        const val BROADCAST_REQUEST_CODE = 1234
+        const val ACTIVITY_REQUEST_CODE = 1235
 
         fun updateWidget(
             context: Context,
@@ -53,6 +54,7 @@ class ScheduleWidget : AppWidgetProvider() {
             if (data == null || data.termStart.isEmpty()) {
                 views.setViewVisibility(R.id.course_group, View.GONE)
                 views.setViewVisibility(R.id.all_done_group, View.VISIBLE)
+                setOnClickAction(context, views)
                 appWidgetManager.updateAppWidget(appWidgetId, views)
                 return
             }
@@ -81,7 +83,8 @@ class ScheduleWidget : AppWidgetProvider() {
                 ScheduleData.parseTimeToMinutes(it.endTime) > nowMin
             }
 
-            val combined = (upcomingToday.map { it to true } + tomorrowCourses.map { it to false }).take(2)
+            val combined =
+                (upcomingToday.map { it to true } + tomorrowCourses.map { it to false }).take(2)
 
             if (combined.isEmpty()) {
                 views.setViewVisibility(R.id.course_group, View.GONE)
@@ -117,14 +120,32 @@ class ScheduleWidget : AppWidgetProvider() {
             if (upcomingToday.isEmpty() && tomorrowCourses.isEmpty()) {
                 hintText = "今天和明天都没有课啦～"
             } else {
-                val todayHint = if (upcomingToday.isEmpty()) "今天没有课啦，" else "今天还有${upcomingToday.size}节课，"
-                val tomorrowHint = if (tomorrowCourses.isEmpty()) "明天没有课啦～" else "明天还有${tomorrowCourses.size}节课"
+                val todayHint =
+                    if (upcomingToday.isEmpty()) "今天没有课啦，" else "今天还有${upcomingToday.size}节课，"
+                val tomorrowHint =
+                    if (tomorrowCourses.isEmpty()) "明天没有课啦～" else "明天还有${tomorrowCourses.size}节课"
                 hintText = todayHint + tomorrowHint
             }
             views.setViewVisibility(R.id.tv_course_hint, View.VISIBLE)
             views.setTextViewText(R.id.tv_course_hint, hintText)
 
+            setOnClickAction(context, views)
             appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        fun setOnClickAction(context: Context, views: RemoteViews) {
+            context.packageManager
+                .getLaunchIntentForPackage(context.packageName)
+                ?.let {
+                    it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    views.setOnClickPendingIntent(
+                        R.id.widget_root,
+                        PendingIntent.getActivity(
+                            context, ACTIVITY_REQUEST_CODE, it,
+                            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+                        )
+                    )
+                }
         }
 
         fun scheduleNextAlarm(context: Context) {
@@ -153,7 +174,7 @@ class ScheduleWidget : AppWidgetProvider() {
                 action = ACTION_AUTO_REFRESH
             }
             val pendingIntent = PendingIntent.getBroadcast(
-                context, REQUEST_CODE, intent,
+                context, BROADCAST_REQUEST_CODE, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 

--- a/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleWidget.kt
+++ b/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleWidget.kt
@@ -20,7 +20,9 @@ class ScheduleWidget : AppWidgetProvider() {
         for (id in appWidgetIds) {
             updateWidget(context, appWidgetManager, id)
         }
-        scheduleNextAlarm(context)
+        if (appWidgetIds.isNotEmpty()) {
+            scheduleNextAlarm(context)
+        }
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -36,6 +38,9 @@ class ScheduleWidget : AppWidgetProvider() {
 
     companion object {
         const val ACTION_AUTO_REFRESH = "dev.tokenteam.iwut.widget.AUTO_REFRESH"
+
+        // Do not use `0` for request code
+        const val REQUEST_CODE = 1234
 
         fun updateWidget(
             context: Context,
@@ -148,12 +153,12 @@ class ScheduleWidget : AppWidgetProvider() {
                 action = ACTION_AUTO_REFRESH
             }
             val pendingIntent = PendingIntent.getBroadcast(
-                context, 0, intent,
+                context, REQUEST_CODE, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
 
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-            alarmManager.setExactAndAllowWhileIdle(
+            alarmManager.set(
                 AlarmManager.RTC_WAKEUP,
                 alarmTime.timeInMillis,
                 pendingIntent


### PR DESCRIPTION
### Android 桌面小组件更改
* `requestCode` 为 `0` 时，`AlarmManager` 设置的 `PendingIntent` 在部分机型实测不会触发，更改为其他数值
* 如果没有小组件，则不再计划更新小组件内容
* 现在点击小组件可进入应用