### PR TITLE
Improve notification ID management, live-activity updates, and auto-dismiss behavior

### DIFF
--- a/modules/notification/android/src/main/java/dev/tokenteam/iwut/notification/NotificationModule.kt
+++ b/modules/notification/android/src/main/java/dev/tokenteam/iwut/notification/NotificationModule.kt
@@ -36,7 +36,7 @@ class NotificationModule : Module() {
             val context = appContext.reactContext ?: return@AsyncFunction null
             val target = targetTimeMs.toLong()
 
-            val notification = buildCountdownNotification(context, channelId, title, body, target, ongoing)
+            val notification = buildCountdownNotification(context, channelId, title, body, target, ongoing, autoDismiss)
             notificationManager?.notify(id, notification)
             null
         }
@@ -46,7 +46,7 @@ class NotificationModule : Module() {
             val trigger = triggerAtMs.toLong()
 
             val intent = Intent(context, CountdownReceiver::class.java).apply {
-                action = "dev.tokenteam.iwut.notification.SHOW_COUNTDOWN"
+                action = CountdownReceiver.ACTION_SHOW_COUNTDOWN
                 putExtra("id", id)
                 putExtra("channelId", channelId)
                 putExtra("title", title)
@@ -92,6 +92,7 @@ class NotificationModule : Module() {
         body: String,
         targetTimeMs: Long,
         ongoing: Boolean,
+        autoDismiss: Boolean,
     ): android.app.Notification {
         val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
         val contentIntent = PendingIntent.getActivity(
@@ -114,7 +115,7 @@ class NotificationModule : Module() {
             .setContentIntent(contentIntent)
             .setAutoCancel(!ongoing)
             .apply {
-                if (timeoutMs > 0) setTimeoutAfter(timeoutMs)
+                if (autoDismiss && timeoutMs > 0) setTimeoutAfter(timeoutMs)
             }
 
         if (Build.VERSION.SDK_INT >= 36) {
@@ -126,12 +127,17 @@ class NotificationModule : Module() {
     }
 
     private fun cancelScheduledAlarm(context: Context, id: Int) {
-        val intent = Intent(context, CountdownReceiver::class.java)
+        val intent = Intent(context, CountdownReceiver::class.java).apply {
+            action = CountdownReceiver.ACTION_SHOW_COUNTDOWN
+        }
         val pendingIntent = PendingIntent.getBroadcast(
             context, id, intent,
             PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
         )
-        pendingIntent?.let { alarmManager?.cancel(it) }
+        pendingIntent?.let {
+            alarmManager?.cancel(it)
+            it.cancel()
+        }
     }
 
     private fun cancelAllScheduledAlarms(context: Context) {
@@ -139,12 +145,20 @@ class NotificationModule : Module() {
         for (id in ids) {
             cancelScheduledAlarm(context, id)
         }
+        cancelLegacySequentialAlarms(context)
         clearTrackedIds(context)
+    }
+
+    private fun cancelLegacySequentialAlarms(context: Context) {
+        for (id in 0 until LEGACY_SEQUENTIAL_ID_LIMIT) {
+            cancelScheduledAlarm(context, id)
+        }
     }
 
     companion object {
         private const val PREFS_NAME = "notification_ids"
         private const val KEY_IDS = "scheduled_ids"
+        private const val LEGACY_SEQUENTIAL_ID_LIMIT = 1024
 
         fun trackScheduledId(context: Context, id: Int) {
             val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/modules/notification/ios/NotificationModule.swift
+++ b/modules/notification/ios/NotificationModule.swift
@@ -66,8 +66,13 @@ public class NotificationModule: Module {
         let content = ActivityContent(state: state, staleDate: targetDate)
 
         if let activity = self.loadLiveActivity(for: id) {
-            await activity.update(content)
-            return
+            if activity.attributes.title == title && activity.attributes.subtitle == body {
+                await activity.update(content)
+                return
+            }
+
+            await activity.end(nil, dismissalPolicy: .immediate)
+            self.removeActivityMapping(id: id)
         }
 
         let attributes = CountdownActivityAttributes(title: title, subtitle: body)

--- a/modules/notification/ios/NotificationModule.swift
+++ b/modules/notification/ios/NotificationModule.swift
@@ -21,7 +21,7 @@ public class NotificationModule: Module {
             let targetDate = Date(timeIntervalSince1970: targetTimeMs / 1000.0)
 
             if #available(iOS 16.2, *) {
-                try self.startLiveActivity(id: id, title: title, body: body, targetDate: targetDate)
+                try await self.startOrUpdateLiveActivity(id: id, title: title, body: body, targetDate: targetDate)
             } else {
                 self.showLocalNotification(id: id, title: title, body: body, triggerDate: nil, autoDismiss: autoDismiss)
             }
@@ -34,7 +34,7 @@ public class NotificationModule: Module {
             if #available(iOS 16.2, *) {
                 let now = Date()
                 if triggerDate <= now {
-                    try self.startLiveActivity(id: id, title: title, body: body, targetDate: targetDate)
+                    try await self.startOrUpdateLiveActivity(id: id, title: title, body: body, targetDate: targetDate)
                 } else {
                     self.scheduleLiveActivityViaNotification(id: id, title: title, body: body, triggerDate: triggerDate, targetDate: targetDate)
                 }
@@ -59,13 +59,18 @@ public class NotificationModule: Module {
     }
 
     @available(iOS 16.2, *)
-    private func startLiveActivity(id: Int, title: String, body: String, targetDate: Date) throws {
+    private func startOrUpdateLiveActivity(id: Int, title: String, body: String, targetDate: Date) async throws {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
-        let attributes = CountdownActivityAttributes(title: title, subtitle: body)
         let state = CountdownActivityAttributes.ContentState(targetTime: targetDate)
-
         let content = ActivityContent(state: state, staleDate: targetDate)
+
+        if let activity = self.loadLiveActivity(for: id) {
+            await activity.update(content)
+            return
+        }
+
+        let attributes = CountdownActivityAttributes(title: title, subtitle: body)
         let activity = try Activity<CountdownActivityAttributes>.request(
             attributes: attributes,
             content: content,
@@ -73,6 +78,18 @@ public class NotificationModule: Module {
         )
 
         self.saveActivityMapping(id: id, activityId: activity.id)
+    }
+
+    @available(iOS 16.2, *)
+    private func loadLiveActivity(for id: Int) -> Activity<CountdownActivityAttributes>? {
+        guard let activityId = self.loadActivityId(for: id) else { return nil }
+
+        if let activity = Activity<CountdownActivityAttributes>.activities.first(where: { $0.id == activityId }) {
+            return activity
+        }
+
+        self.removeActivityMapping(id: id)
+        return nil
     }
 
     @available(iOS 16.2, *)
@@ -108,8 +125,11 @@ public class NotificationModule: Module {
         let interval = triggerDate.timeIntervalSinceNow
         guard interval > 0 else { return }
 
+        let identifier = "notification_\(id)"
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
-        let request = UNNotificationRequest(identifier: "notification_\(id)", content: content, trigger: trigger)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
         UNUserNotificationCenter.current().add(request)
     }
 
@@ -128,7 +148,10 @@ public class NotificationModule: Module {
             trigger = nil
         }
 
-        let request = UNNotificationRequest(identifier: "notification_\(id)", content: content, trigger: trigger)
+        let identifier = "notification_\(id)"
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
         UNUserNotificationCenter.current().add(request)
     }
 

--- a/services/course-notification.ts
+++ b/services/course-notification.ts
@@ -19,6 +19,58 @@ const BACKGROUND_TASK_NAME = "course-reminder-refresh";
 const SCHEDULE_WEEKS = 2;
 const LIVE_ACTIVITY_ID = 9999;
 
+function hashReminderId(input: string): number {
+  let hash = 0x811c9dc5;
+
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return hash & 0x7fffffff;
+}
+
+function getReminderId(
+  termStart: string,
+  week: number,
+  course: {
+    name: string;
+    room: string;
+    teacher: string;
+    day: number;
+    sectionStart: number;
+    sectionEnd: number;
+  },
+  classStartMs: number,
+): number {
+  const id = hashReminderId(
+    [
+      termStart,
+      week,
+      course.day,
+      course.sectionStart,
+      course.sectionEnd,
+      classStartMs,
+      course.name,
+      course.room,
+      course.teacher,
+    ].join("|"),
+  );
+
+  return id === LIVE_ACTIVITY_ID ? LIVE_ACTIVITY_ID + 1 : id;
+}
+
+function reserveReminderId(baseId: number, scheduledIds: Set<number>): number {
+  let id = baseId;
+
+  while (scheduledIds.has(id) || id === LIVE_ACTIVITY_ID) {
+    id = (id + 1) & 0x7fffffff;
+  }
+
+  scheduledIds.add(id);
+  return id;
+}
+
 TaskManager.defineTask(BACKGROUND_TASK_NAME, async () => {
   try {
     await initNotificationChannel();
@@ -132,7 +184,7 @@ export async function scheduleWeeklyReminders(): Promise<void> {
 
   const currentWeek = getCurrentWeek(termStart);
   const now = Date.now();
-  let idCounter = 0;
+  const scheduledIds = new Set<number>();
 
   for (let offset = 0; offset < SCHEDULE_WEEKS; offset++) {
     const week = currentWeek + offset;
@@ -157,8 +209,13 @@ export async function scheduleWeeklyReminders(): Promise<void> {
 
       if (triggerAtMs <= now) continue;
 
+      const id = reserveReminderId(
+        getReminderId(termStart, week, course, classStartMs),
+        scheduledIds,
+      );
+
       await scheduleCountdown(
-        idCounter++,
+        id,
         CHANNEL_ID,
         course.name,
         `${course.room} · ${startTimeStr}`,


### PR DESCRIPTION
### Motivation
- Prevent notification ID collisions and legacy-sequential alarm leftovers when scheduling countdown reminders. 
- Allow notifications to respect an `autoDismiss` flag so countdown notifications can expire automatically when desired. 
- Ensure iOS live activities are updated when already active and that scheduled notifications are deduplicated and cleaned up.

### Description
- Android: propagate `autoDismiss` into `buildCountdownNotification`, use `CountdownReceiver.ACTION_SHOW_COUNTDOWN` constant for intents, cancel and call `PendingIntent.cancel()` when removing alarms, and add `cancelLegacySequentialAlarms` plus `LEGACY_SEQUENTIAL_ID_LIMIT` to clear legacy IDs. 
- iOS: convert `startLiveActivity` into `startOrUpdateLiveActivity` (async) which updates an existing Activity if present, add `loadLiveActivity` helper and persistence mapping fixes, and remove pending/delivered notifications before scheduling to avoid duplicates. 
- TypeScript/service: replace ad-hoc incremental IDs with deterministic hashed reminder IDs via `hashReminderId` and `getReminderId`, add `reserveReminderId` to avoid collisions (and avoid the reserved `LIVE_ACTIVITY_ID`), and use the reserved id when calling `scheduleCountdown`.

### Testing
- Ran TypeScript type checking (`tsc`) and linting (`eslint`) on the modified files and they passed. 
- No new automated unit tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27ce04ca9c8329ac0f4511fa6dc7cd)