### PR TITLE
添加网络缴费入口

### DIFF
--- a/app/(tabs)/function.tsx
+++ b/app/(tabs)/function.tsx
@@ -97,6 +97,13 @@ const SECTIONS: Section[] = [
         uri: "https://zhlgd.whut.edu.cn/tpass/login?service=http://nyyzf.whut.edu.cn/MobileWebOnlineHall/#/",
         lan: false,
       },
+      {
+        icon: "wifi-outline",
+        labelKey: "fn.app.netPay",
+        color: "#2563eb",
+        uri: "https://zhlgd.whut.edu.cn/tpass/login?service=http://cwsf.whut.edu.cn/netdetails515N023",
+        lan: false,
+      },
     ],
   },
   {

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -205,6 +205,7 @@
       "library": "Library",
       "card": "Campus Card",
       "elec": "Electricity",
+      "netPay": "Network Payment",
       "campusNews": "Campus News"
     },
     "openUrl": "Open URL",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -205,6 +205,7 @@
       "library": "图书馆管家",
       "card": "智寻卡片",
       "elec": "电费查询",
+      "netPay": "网络缴费",
       "campusNews": "校园公告"
     },
     "openUrl": "打开网页",


### PR DESCRIPTION
## 变更内容

- 在功能页的生活服务区域新增「网络缴费」入口。
- 入口使用统一身份认证包装后的服务地址，复用当前 WebView/CAS 登录状态，行为与电费查询保持一致。
- 补充中英文多语言文案。

## 验证

- `bun run lint`
- 已本地打包 preview APK 供手动检查

## 影响范围

- 仅新增功能入口与文案，不改动登录流程和缴费页面逻辑。