### PR TITLE
fix: 修复假期小组件时间显示问题

### DIFF
--- a/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleData.kt
+++ b/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleData.kt
@@ -6,11 +6,10 @@ import android.content.res.Configuration
 import android.os.Build
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
-import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import java.util.concurrent.TimeUnit
+import java.util.TimeZone
 
 data class WidgetCourse(
     @SerializedName("name") val name: String = "",
@@ -84,17 +83,30 @@ object ScheduleData {
     }
 
     private fun getWeek(termStart: String, now: Date): Int {
-        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-        val startDate = try {
-            sdf.parse(termStart) ?: return 1
-        } catch (e: Exception) {
-            return 1
-        }
-        val diffMs = now.time - startDate.time
-        if (diffMs < 0) return 0
-        val diffDays = TimeUnit.MILLISECONDS.toDays(diffMs)
+        val match = Regex("^(\\d{4})-(\\d{1,2})-(\\d{1,2})").find(termStart) ?: return 1
+        val startDay = normalizedDay(
+            match.groupValues[1].toInt(),
+            match.groupValues[2].toInt() - 1,
+            match.groupValues[3].toInt(),
+        )
+        val nowCalendar = Calendar.getInstance().apply { time = now }
+        val nowDay = normalizedDay(
+            nowCalendar.get(Calendar.YEAR),
+            nowCalendar.get(Calendar.MONTH),
+            nowCalendar.get(Calendar.DAY_OF_MONTH),
+        )
+        val diffDays = (nowDay - startDay) / DAY_MS
+        if (diffDays < 0) return 0
         return (diffDays / 7 + 1).toInt()
     }
+
+    private fun normalizedDay(year: Int, month: Int, day: Int): Long =
+        Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+            clear()
+            set(year, month, day)
+        }.timeInMillis
+
+    private const val DAY_MS = 24 * 60 * 60 * 1000L
 
     fun getCurrentWeek(termStart: String): Int =
         getWeek(termStart, Calendar.getInstance().time)

--- a/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleData.kt
+++ b/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleData.kt
@@ -8,6 +8,7 @@ import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import java.util.Calendar
 import java.util.Date
+import java.util.GregorianCalendar
 import java.util.Locale
 import java.util.TimeZone
 
@@ -89,7 +90,7 @@ object ScheduleData {
             match.groupValues[2].toInt() - 1,
             match.groupValues[3].toInt(),
         )
-        val nowCalendar = Calendar.getInstance().apply { time = now }
+        val nowCalendar = localCalendar().apply { time = now }
         val nowDay = normalizedDay(
             nowCalendar.get(Calendar.YEAR),
             nowCalendar.get(Calendar.MONTH),
@@ -101,18 +102,21 @@ object ScheduleData {
     }
 
     private fun normalizedDay(year: Int, month: Int, day: Int): Long =
-        Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+        GregorianCalendar(TimeZone.getTimeZone("UTC"), Locale.US).apply {
             clear()
             set(year, month, day)
         }.timeInMillis
 
+    private fun localCalendar(): Calendar =
+        GregorianCalendar(TimeZone.getDefault(), Locale.US)
+
     private const val DAY_MS = 24 * 60 * 60 * 1000L
 
     fun getCurrentWeek(termStart: String): Int =
-        getWeek(termStart, Calendar.getInstance().time)
+        getWeek(termStart, Date())
 
     fun getDayOfWeek(): Int {
-        val cal = Calendar.getInstance()
+        val cal = localCalendar()
         val dow = cal.get(Calendar.DAY_OF_WEEK)
         return if (dow == Calendar.SUNDAY) 7 else dow - 1
     }
@@ -123,7 +127,7 @@ object ScheduleData {
     }
 
     fun getTomorrowWeek(termStart: String): Int {
-        val tomorrow = Calendar.getInstance().apply {
+        val tomorrow = localCalendar().apply {
             add(Calendar.DAY_OF_YEAR, 1)
         }.time
         return getWeek(termStart, tomorrow)
@@ -133,7 +137,7 @@ object ScheduleData {
         context.getString(R.string.widget_week_n, week)
 
     fun getDateStr(context: Context): String {
-        val cal = Calendar.getInstance()
+        val cal = localCalendar()
         return context.getString(
             R.string.widget_month_day,
             cal.get(Calendar.MONTH) + 1,

--- a/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleData.kt
+++ b/modules/widget/android/src/main/java/dev/tokenteam/iwut/widget/ScheduleData.kt
@@ -8,6 +8,7 @@ import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -82,19 +83,21 @@ object ScheduleData {
         return if (locales.isEmpty) Locale.getDefault() else locales.get(0)
     }
 
-    fun getCurrentWeek(termStart: String): Int {
+    private fun getWeek(termStart: String, now: Date): Int {
         val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
         val startDate = try {
             sdf.parse(termStart) ?: return 1
         } catch (e: Exception) {
             return 1
         }
-        val now = Calendar.getInstance().time
         val diffMs = now.time - startDate.time
         if (diffMs < 0) return 0
         val diffDays = TimeUnit.MILLISECONDS.toDays(diffMs)
         return (diffDays / 7 + 1).toInt()
     }
+
+    fun getCurrentWeek(termStart: String): Int =
+        getWeek(termStart, Calendar.getInstance().time)
 
     fun getDayOfWeek(): Int {
         val cal = Calendar.getInstance()
@@ -108,9 +111,10 @@ object ScheduleData {
     }
 
     fun getTomorrowWeek(termStart: String): Int {
-        val today = getDayOfWeek()
-        val week = getCurrentWeek(termStart)
-        return if (today == 7) week + 1 else week
+        val tomorrow = Calendar.getInstance().apply {
+            add(Calendar.DAY_OF_YEAR, 1)
+        }.time
+        return getWeek(termStart, tomorrow)
     }
 
     fun getWeekStr(context: Context, week: Int): String =

--- a/targets/widget/Models/WidgetData.swift
+++ b/targets/widget/Models/WidgetData.swift
@@ -122,9 +122,8 @@ struct ScheduleHelper {
     }
 
     static func tomorrowWeek(termStart: String, now: Date) -> Int {
-        let today = dayOfWeek(for: now)
-        let week = currentWeek(termStart: termStart, now: now)
-        return today == 7 ? week + 1 : week
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: now) ?? now
+        return currentWeek(termStart: termStart, now: tomorrow)
     }
 
     static func weekStr(week: Int) -> String {


### PR DESCRIPTION
fix #30 

### Motivation

- Ensure week calculations can be evaluated for an arbitrary `Date` so tomorrow/week transitions are computed consistently across platforms.
- Unify logic so the "tomorrow" week uses the start-of-day-aware week computation instead of ad-hoc day checks.

### Description

- Kotlin: extracted a private helper `getWeek(termStart: String, now: Date)` and made `getCurrentWeek` delegate to it, and added `import java.util.Date` for the new parameter type. 
- Kotlin: updated `getTomorrowWeek` to compute the tomorrow `Date` via `Calendar.add(Calendar.DAY_OF_YEAR, 1)` and call `getWeek` with that date. 
- Swift: updated `tomorrowWeek(termStart: String, now: Date)` to compute `tomorrow` using `Calendar.current.date(byAdding:.day, value: 1, to: now)` and call `currentWeek(termStart:now:)` for the result.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65cb62c0348329a1e72e458c35c602)